### PR TITLE
Don't use DST offset - fixes 1h time shift in round trip

### DIFF
--- a/src/ISO8601_lexer.mll
+++ b/src/ISO8601_lexer.mll
@@ -3,7 +3,7 @@
 
   (* Date helpers *)
   let mkdate y m d =
-    let (t, tm) = Unix.mktime {
+    let (t, _tm) = Unix.mktime {
                       Unix.tm_sec = 0 ;
                       tm_min = 0 ;
                       tm_hour = 0 ;
@@ -15,7 +15,7 @@
                       tm_isdst = false ; } in
     let offset = fst (Unix.mktime (Unix.gmtime 0. )) in
     (* FIXME: Ensure the daylight saving time correction is right. *)
-    t -. offset +. (if tm.Unix.tm_isdst then 3600. else 0.)
+    t -. offset
 
   let ymd y m d = mkdate (int y) (int m) (int d)
   let ym y m = mkdate (int y) (int m) 1

--- a/tests/utils.ml
+++ b/tests/utils.ml
@@ -1,13 +1,13 @@
 let local_offset = fst (Unix.mktime (Unix.gmtime 0.))
 
 let mkdatetime y m d h mi s =
-  let (t, tm)=
+  let (t, _tm)=
     Unix.mktime { Unix.tm_sec = s ; tm_min = mi ; tm_hour = h ;
                   tm_wday = -1 ; tm_yday = -1 ; tm_isdst = false ;
                   tm_mday = d ;
                   tm_mon = m - 1 ;
                   tm_year = y - 1900 ; } in
-  t -. local_offset +. (if tm.Unix.tm_isdst then 3600. else 0.)
+  t -. local_offset
 
 let mkdate y m d = mkdatetime y m d 0 0 0
 


### PR DESCRIPTION
The current implmentation calculates a an offset based on Daylight
Saving Time being in effect at the Epoch:

  t -. offset +. (if tm.Unix.tm_isdst then 3600. else 0.)

This leads to suprises in the Europe/London timezone where unparsing and
parsing a date leads to an offset - see this issue:

  https://github.com/ocaml-community/ISO8601.ml/issues/17

The following change eliminates this and makes all unit tests pass.
Somewhat surprisingly the knowledge about this offset is encoded both in
the implementation and the unit tests.

Likewise surprising, the offset is not zero in the Europe/London
timezone but it seems to be consistent over various Unix
implementations.

Signed-off-by: Christian Lindig <lindig@gmail.com>